### PR TITLE
Fix repository URL in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This Cloud App Requires:
 ### Installing
 
 ```
-git clone https://github.com/happydata/bigspender.git
+git clone https://github.com/happydata/cloudapp-bigspender.git
 cd bigspender
 npm install
 ```


### PR DESCRIPTION
The URL for cloning is incorrect and doesn't resolve to any GitHub repository.
